### PR TITLE
Assert trusted-certs property value is a string

### DIFF
--- a/jobs/cflinuxfs2-rootfs-setup/spec
+++ b/jobs/cflinuxfs2-rootfs-setup/spec
@@ -10,4 +10,11 @@ packages:
 
 properties:
   cflinuxfs2-rootfs.trusted_certs:
-    description: "certficates to add to the rootfs trust store"
+    description: "Concatenation of PEM-encoded CA certficates to add to the rootfs trust store."
+    example: |
+      -----BEGIN CERTIFICATE-----
+      (contents of certificate #1)
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      (contents of certificate #2)
+      -----END CERTIFICATE-----

--- a/jobs/cflinuxfs2-rootfs-setup/templates/trusted_ca.crt.erb
+++ b/jobs/cflinuxfs2-rootfs-setup/templates/trusted_ca.crt.erb
@@ -1,1 +1,7 @@
-<%= p("cflinuxfs2-rootfs.trusted_certs", "") %>
+<%=
+  certs = p("cflinuxfs2-rootfs.trusted_certs", "")
+
+  raise("The 'cflinuxfs2-rootfs.trusted_certs' property must be string-valued") unless certs.is_a? String
+
+  certs
+%>


### PR DESCRIPTION
Supplying a different type, such as an array of strings, causes job-template rendering to fail at the start of the deploy, before updating any BOSH VM instances.

Also, improve setup job spec with property description and example.